### PR TITLE
Remove config_template usage

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,11 +14,9 @@
 # limitations under the License.
 
 - name: Drop the anycast service units
-  config_template:
+  template:
     src: anycast-interface.service.j2
     dest: "/etc/systemd/system/{{ item.filename | default(anycast_default_filename) }}"
-    config_overrides: "{{ item.service_overrides | default({}) }}"
-    config_type: ini
   with_items: "{{ anycast_config }}"
   register: anycast_service_unit
   notify:


### PR DESCRIPTION
A config_template commit[0] broke rendering of the file[1][2] so that
addresses are added to the net_anycast interface prior to its creation,
breaking the systemd unit.

[0] https://opendev.org/openstack/ansible-config_template/commit/09c76e238026d7ba4134ee2b66a4e9fd2617b843
[1] http://paste.openstack.org/raw/787413/ (before)
[2] http://paste.openstack.org/raw/787412/ (after)